### PR TITLE
Separate out the API key into its own config file

### DIFF
--- a/API_KEY.js
+++ b/API_KEY.js
@@ -1,0 +1,3 @@
+/* This file contains the 2Captcha private API key secret */
+
+const API_KEY = 'PUT YOUR API KEY HERE'

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
                 "content/style.css"
             ],
             "js": [
+                "API_KEY.js",
                 "vendor/jquery/3.5.1/jquery.min.js",
                 "common/config.js",
                 "content/core_helpers.js",


### PR DESCRIPTION
This way, the main config file can be kept inside the published repo, whereas the API key stays out of the repo.

I am including 2captcha in https://github.com/rdancer/brute-lee -- but in order to have the code ready to run, I need to include `common/config.js`; this is a problem because the private API key secret lives there, and that shouldn't be distributed.

Ideally this should be loaded from an external file such as ~/.2captcha-api-key.json, but Chrome Extensions probably cannot access the general filesystem.